### PR TITLE
fix: hydration error

### DIFF
--- a/src/components/breadcrumb.tsx
+++ b/src/components/breadcrumb.tsx
@@ -19,7 +19,7 @@ export default function Breadcrumb({ entries }: IBreadcrumb): JSX.Element {
     >
       {entries.length > 1 &&
         entries.map((entry, index, array) => (
-          <ListItem key={entry.label}>
+          <ListItem key={entry.breadcrumb}>
             {array.length === index + 1 ? (
               <Box as="span" fontWeight="bold">
                 {entry.label}

--- a/src/components/product/Price.tsx
+++ b/src/components/product/Price.tsx
@@ -1,18 +1,25 @@
 import { useColorModeValue, Text } from "@chakra-ui/react";
+import { TextProps } from "@chakra-ui/layout";
 
-interface IPriceProps {
+interface IPriceProps extends TextProps {
   price: string;
   currency: string;
   size?: string;
 }
 
-const Price = ({ price, currency, size = "2xl" }: IPriceProps): JSX.Element => {
+const Price = ({
+  price,
+  currency,
+  size = "2xl",
+  ...props
+}: IPriceProps): JSX.Element => {
   return (
     <Text
       color={useColorModeValue("gray.900", "gray.400")}
       fontWeight={300}
       marginTop="15px"
       fontSize={size}
+      {...props}
     >
       {price} {currency}
     </Text>

--- a/src/components/product/StrikePrice.tsx
+++ b/src/components/product/StrikePrice.tsx
@@ -1,11 +1,12 @@
 import { useColorModeValue, Text } from "@chakra-ui/react";
+import { TextProps } from "@chakra-ui/layout";
 
-interface IPrice {
+interface IPrice extends TextProps {
   price: string;
   currency: string;
 }
 
-const StrikePrice = ({ price, currency }: IPrice): JSX.Element => {
+const StrikePrice = ({ price, currency, ...props }: IPrice): JSX.Element => {
   return (
     <Text
       color={useColorModeValue("red.500", "red.200")}
@@ -14,6 +15,7 @@ const StrikePrice = ({ price, currency }: IPrice): JSX.Element => {
       fontSize="lg"
       textDecoration="line-through"
       ml={3}
+      {...props}
     >
       {price} {currency}
     </Text>

--- a/src/components/search/Hit.tsx
+++ b/src/components/search/Hit.tsx
@@ -64,21 +64,20 @@ export default function HitComponent({ hit }: { hit: SearchHit }): JSX.Element {
         >
           {ep_description}
         </Text>
-        <Text fontSize="md" fontWeight="semibold" mt="1">
-          {ep_price && (
-            <Flex alignItems="center">
-              <Price price={ep_price["USD"].formatted_price} currency="USD" />
-              {ep_price["USD"].sale_prices && (
-                <StrikePrice
-                  price={
-                    ep_price["USD"].sale_prices.original_price.formatted_price
-                  }
-                  currency="USD"
-                />
-              )}
-            </Flex>
-          )}
-        </Text>
+        {ep_price && (
+          <Flex alignItems="center" mt="1">
+            <Price price={ep_price["USD"].formatted_price} currency="USD" />
+            {ep_price["USD"].sale_prices && (
+              <StrikePrice
+                price={
+                  ep_price["USD"].sale_prices.original_price.formatted_price
+                }
+                currency="USD"
+                fontSize="lg"
+              />
+            )}
+          </Flex>
+        )}
         <Button
           rounded="md"
           w="full"


### PR DESCRIPTION
# Hydration error during development
## Breadcrumb
- breadcrumb keys are now unique using breadcrumb property instead of value

## Price Component
- Chakra text was rendering inside itself. Can't have `<p>` inside of `<p>`