### PR TITLE
fix: instantsearch server error

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "react": "^18.2.0",
     "react-device-detect": "^2.2.2",
     "react-dom": "^18.2.0",
-    "react-instantsearch-hooks-server": "^6.32.0",
-    "react-instantsearch-hooks-web": "^6.32.0",
+    "react-instantsearch-hooks-server": "6.38.1",
+    "react-instantsearch-hooks-web": "6.38.1",
     "rxjs": "^7.5.7",
     "yup": "^1.0.0-beta.7",
     "zlib": "^1.0.5"

--- a/src/lib/search-props.tsx
+++ b/src/lib/search-props.tsx
@@ -7,6 +7,7 @@ import type { FunctionComponent } from "react";
 import React from "react";
 import { BreadcrumbEntry, createBreadcrumb } from "./create-breadcrumb";
 import { BreadcrumbLookup } from "./types/breadcrumb-lookup";
+import { renderToString } from "react-dom/server";
 
 export interface SearchQuery extends ParsedUrlQuery {
   nodeId: string;
@@ -38,7 +39,8 @@ export const getSearchSSRProps =
         node={node}
         breadcrumbEntries={breadcrumbEntries}
         lookup={lookup}
-      />
+      />,
+      { renderToString }
     );
 
     return {


### PR DESCRIPTION
was getting a log message server side after the latest `react-instantsearch-hooks-server` and `react-instantsearch-hooks-web` update.

```
[InstantSearch] `renderToString` should be passed to getServerState(<App/>, { renderToString })
```

- fixes the version of `react-instantsearch-hooks-web` and `react-instantsearch-hooks-server` to 6.38.1
- adds renderToString as an option argument