### PR TITLE
fix: repaired link after bad refactor

### DIFF
--- a/src/components/header/cart/CartMenu.tsx
+++ b/src/components/header/cart/CartMenu.tsx
@@ -96,7 +96,7 @@ function CartPopoverFooter({
           Checkout
         </Button>
       </Link>
-      <Link href="/src/pages/cart" passHref>
+      <Link href="/cart" passHref>
         <Button
           onClick={onClose}
           _hover={{


### PR DESCRIPTION
The link to the cart page was replaced with an automatic refactor to the same as it's imported path. This has been fixed.