### PR TITLE
feat: seo optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ ep_extensions_products_specifications.brand
 ep_extensions_products_specifications.on-sale
 ep_extensions_products_specifications.color
 ```
+
 In order to use faceting add the attribute name to the list of attributes in Facets and Facet display sections of Algolia dashboard in Configuration menu.
 Use default settings.
 

--- a/src/components/cart/CartOrderSummary.tsx
+++ b/src/components/cart/CartOrderSummary.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   Button,
   Grid,
+  Heading,
   Table,
   Tbody,
   Td,
@@ -28,9 +29,9 @@ export function CartOrderSummary({
 }): JSX.Element {
   return (
     <Box backgroundColor="gray.50" p={8} borderRadius={6}>
-      <Text fontSize="lg" fontWeight={500}>
+      <Heading fontSize="18px" fontWeight={500}>
         Order Summary
-      </Text>
+      </Heading>
       <Table variant="simple">
         <Tbody>
           <Tr fontSize={14}>

--- a/src/components/featured-products/FeaturedProducts.tsx
+++ b/src/components/featured-products/FeaturedProducts.tsx
@@ -124,6 +124,7 @@ const FeaturedProducts = (props: IFeaturedProductsProps): JSX.Element => {
                   borderRadius={5}
                   objectFit="cover"
                   boxShadow="sm"
+                  quality={100}
                 />
               ) : (
                 <Center

--- a/src/components/featured-products/FeaturedProducts.tsx
+++ b/src/components/featured-products/FeaturedProducts.tsx
@@ -14,6 +14,7 @@ import type { ProductResponseWithImage } from "../../lib/types/product-types";
 import { connectProductsWithMainImages } from "../../lib/product-util";
 import { ArrowForwardIcon, ViewOffIcon } from "@chakra-ui/icons";
 import { globalBaseWidth } from "../../styles/theme";
+import { ChakraNextImage } from "../ChakraNextImage";
 
 interface IFeaturedProductsBaseProps {
   title: string;
@@ -115,7 +116,7 @@ const FeaturedProducts = (props: IFeaturedProductsProps): JSX.Element => {
           >
             <Box width="100%" maxW={64} textAlign="center">
               {product.main_image?.link.href ? (
-                <Image
+                <ChakraNextImage
                   width={64}
                   height={64}
                   alt={product.main_image?.file_name || "Empty"}
@@ -138,9 +139,9 @@ const FeaturedProducts = (props: IFeaturedProductsProps): JSX.Element => {
                 </Center>
               )}
 
-              <Text p="2" fontWeight="semibold">
+              <Heading as="h6" p="2" fontWeight="semibold">
                 {product.attributes.name}
-              </Text>
+              </Heading>
               <Text>{product.meta.display_price?.without_tax.formatted}</Text>
             </Box>
           </Link>

--- a/src/components/featured-products/FeaturedProducts.tsx
+++ b/src/components/featured-products/FeaturedProducts.tsx
@@ -140,7 +140,7 @@ const FeaturedProducts = (props: IFeaturedProductsProps): JSX.Element => {
                 </Center>
               )}
 
-              <Heading as="h6" p="2" fontWeight="semibold">
+              <Heading size="sm" p="2" fontWeight="semibold">
                 {product.attributes.name}
               </Heading>
               <Text>{product.meta.display_price?.without_tax.formatted}</Text>

--- a/src/components/featured-products/FeaturedProducts.tsx
+++ b/src/components/featured-products/FeaturedProducts.tsx
@@ -135,7 +135,9 @@ const FeaturedProducts = (props: IFeaturedProductsProps): JSX.Element => {
               <Heading size="sm" p="2" fontWeight="semibold">
                 {product.attributes.name}
               </Heading>
-              <Text>{product.meta.display_price?.without_tax.formatted}</Text>
+              <Heading size="sm">
+                {product.meta.display_price?.without_tax.formatted}
+              </Heading>
             </Box>
           </Link>
         ))}

--- a/src/components/featured-products/FeaturedProducts.tsx
+++ b/src/components/featured-products/FeaturedProducts.tsx
@@ -1,12 +1,4 @@
-import {
-  Box,
-  Center,
-  Flex,
-  Heading,
-  Image,
-  Link,
-  Text,
-} from "@chakra-ui/react";
+import { Box, Center, Flex, Heading, Link, Text } from "@chakra-ui/react";
 import React, { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { getProductsByNode } from "../../services/hierarchy";

--- a/src/components/layouts/MainLayout.tsx
+++ b/src/components/layouts/MainLayout.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 import type { NavigationNode } from "../../lib/build-site-navigation";
 import { Toaster } from "../toast/toaster";
 import Head from "next/head";
+export const MAIN_LAYOUT_TITLE = "D2C Starter Kit";
 
 interface IMainLayout {
   nav: NavigationNode[];
@@ -15,7 +16,7 @@ const MainLayout = ({ nav, children }: IMainLayout): JSX.Element => {
   return (
     <>
       <Head>
-        <title>D2C Starter Kit</title>
+        <title>{MAIN_LAYOUT_TITLE}</title>
         <meta
           name="description"
           content="D2C Starter Kit - a store front starter for Elastic Path Commerce Cloud"

--- a/src/components/product/ProductDetails.tsx
+++ b/src/components/product/ProductDetails.tsx
@@ -4,6 +4,7 @@ import {
   Stack,
   StackDivider,
   useColorModeValue,
+  Heading,
 } from "@chakra-ui/react";
 import type { ProductResponse } from "@moltin/sdk";
 import { useContext } from "react";
@@ -26,7 +27,7 @@ const ProductDetails = ({ product }: IProductDetails): JSX.Element => {
       {...(context?.isChangingSku ? changingSkuStyle : {})}
     >
       <Box>
-        <Text
+        <Heading
           fontSize={{ base: "16px", lg: "18px" }}
           color="gray.800"
           fontWeight="500"
@@ -34,7 +35,7 @@ const ProductDetails = ({ product }: IProductDetails): JSX.Element => {
           mb="4"
         >
           Product Details
-        </Text>
+        </Heading>
         <Text>{product.attributes.description}</Text>
       </Box>
     </Stack>

--- a/src/components/promotion-banner/PromotionBanner.tsx
+++ b/src/components/promotion-banner/PromotionBanner.tsx
@@ -80,7 +80,7 @@ const PromotionBanner = (props: IPromotionBanner): JSX.Element => {
             </Heading>
           )}
           {description && (
-            <Heading as="h6" zIndex={1}>
+            <Heading size="sm" zIndex={1}>
               {description}
             </Heading>
           )}

--- a/src/components/promotion-banner/PromotionBanner.tsx
+++ b/src/components/promotion-banner/PromotionBanner.tsx
@@ -79,7 +79,11 @@ const PromotionBanner = (props: IPromotionBanner): JSX.Element => {
               {name}
             </Heading>
           )}
-          {description && <Text zIndex={1}>{description}</Text>}
+          {description && (
+            <Heading as="h6" zIndex={1}>
+              {description}
+            </Heading>
+          )}
           {linkProps && (
             <Button
               bg="brand.primary"

--- a/src/components/search/Hit.tsx
+++ b/src/components/search/Hit.tsx
@@ -11,12 +11,12 @@ import {
   LinkOverlay,
   Text,
   useColorModeValue,
+  useDisclosure,
 } from "@chakra-ui/react";
 import { ViewOffIcon } from "@chakra-ui/icons";
 import Link from "next/link";
 import Price from "../product/Price";
 import StrikePrice from "../product/StrikePrice";
-import { useDisclosure } from "@chakra-ui/react";
 import { ProductModalContainer } from "../product-modal/ProductModalContainer";
 
 export default function HitComponent({ hit }: { hit: SearchHit }): JSX.Element {

--- a/src/components/search/SearchPage.tsx
+++ b/src/components/search/SearchPage.tsx
@@ -11,8 +11,9 @@ import { ISearch } from "../../lib/search-props";
 import { useNextRouterHandler } from "../../lib/use-next-router-handler";
 import { resolveRouting } from "../../lib/algolia-search-routing";
 import Breadcrumb from "../breadcrumb";
+import { NextPageWithLayout } from "../../pages/_app";
 
-export const Search = ({
+export const Search: NextPageWithLayout<ISearch> = ({
   algoliaServerState,
   url,
   node,

--- a/src/lib/get-main-layout.tsx
+++ b/src/lib/get-main-layout.tsx
@@ -1,6 +1,10 @@
 import MainLayout from "../components/layouts/MainLayout";
 import { GetLayoutFn } from "../pages/_app";
 
-export const getMainLayout: GetLayoutFn = (page, ctx) => {
+export const getMainLayout: GetLayoutFn<Record<string, any>> = (
+  page,
+  _pageProps,
+  ctx
+) => {
   return <MainLayout nav={ctx?.nav ?? []}>{page}</MainLayout>;
 };

--- a/src/lib/search-props.tsx
+++ b/src/lib/search-props.tsx
@@ -1,14 +1,13 @@
 import type { GetServerSideProps } from "next";
+import type { NextPage } from "next";
 import type { ParsedUrlQuery } from "querystring";
 import type { InstantSearchServerState } from "react-instantsearch-hooks-web";
 
 import { getServerState } from "react-instantsearch-hooks-server";
-import type { FunctionComponent } from "react";
 import React from "react";
 import { BreadcrumbEntry, createBreadcrumb } from "./create-breadcrumb";
 import { BreadcrumbLookup } from "./types/breadcrumb-lookup";
 import { renderToString } from "react-dom/server";
-import { NextPageWithLayout } from "../pages/_app";
 
 export interface SearchQuery extends ParsedUrlQuery {
   nodeId: string;
@@ -24,7 +23,7 @@ export interface ISearch {
 
 export const getSearchSSRProps =
   (
-    SearchComponent: NextPageWithLayout<ISearch>,
+    SearchComponent: NextPage<ISearch>,
     lookup: BreadcrumbLookup
   ): GetServerSideProps<ISearch, SearchQuery> =>
   async ({ req, params }) => {

--- a/src/lib/search-props.tsx
+++ b/src/lib/search-props.tsx
@@ -8,6 +8,7 @@ import React from "react";
 import { BreadcrumbEntry, createBreadcrumb } from "./create-breadcrumb";
 import { BreadcrumbLookup } from "./types/breadcrumb-lookup";
 import { renderToString } from "react-dom/server";
+import { NextPageWithLayout } from "../pages/_app";
 
 export interface SearchQuery extends ParsedUrlQuery {
   nodeId: string;
@@ -23,7 +24,7 @@ export interface ISearch {
 
 export const getSearchSSRProps =
   (
-    SearchComponent: FunctionComponent<ISearch>,
+    SearchComponent: NextPageWithLayout<ISearch>,
     lookup: BreadcrumbLookup
   ): GetServerSideProps<ISearch, SearchQuery> =>
   async ({ req, params }) => {

--- a/src/lib/use-next-router-handler.ts
+++ b/src/lib/use-next-router-handler.ts
@@ -113,12 +113,15 @@ export function useNextRouterHandler<
   }
 
   const params = urlToParams(url);
-  const nodePath = new URL(url).pathname.replace("/search/", "").split("/");
-
+  const pathName = new URL(url).pathname;
+  let nodePath;
+  if (pathName !== "/search") {
+    nodePath = pathName.replace("/search/", "")?.split("/");
+  }
   return {
     initialUiState: routeToState({
       ...params,
-      node: nodePath,
+      ...(nodePath ? { node: nodePath } : {}),
     } as unknown as TRouteParams),
     NextRouterHandler: useCallback(
       () =>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -19,8 +19,9 @@ interface CustomAppProps {
   store: StoreContext | undefined;
 }
 
-export type GetLayoutFn = (
+export type GetLayoutFn<P> = (
   page: ReactElement,
+  pageProps: P,
   storeContext?: StoreContext
 ) => ReactNode;
 
@@ -28,7 +29,7 @@ export type GetLayoutFn = (
  * Adds getLayout function as possible prop on Components
  */
 export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
-  getLayout?: GetLayoutFn;
+  getLayout?: GetLayoutFn<P>;
 };
 
 function MyApp({ Component, pageProps }: AppProps<CustomAppProps>) {
@@ -36,7 +37,7 @@ function MyApp({ Component, pageProps }: AppProps<CustomAppProps>) {
   return (
     <ChakraProvider theme={theme}>
       <StoreNextJSProvider storeContext={pageProps.store}>
-        {getLayout(<Component {...pageProps} />, pageProps.store)}
+        {getLayout(<Component {...pageProps} />, pageProps, pageProps.store)}
       </StoreNextJSProvider>
     </ChakraProvider>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -38,7 +38,7 @@ const Home: NextPage<IHome> = ({ promotion, featuredProducts }) => {
             <FeaturedProducts
               title="Trending Products"
               linkProps={{
-                link: `/category/${nodeId}`,
+                link: `/search`,
                 text: "See all products",
               }}
               type="provided"

--- a/src/pages/products/[productId].tsx
+++ b/src/pages/products/[productId].tsx
@@ -21,7 +21,9 @@ import {
 } from "../../lib/retrieve-product-props";
 import Head from "next/head";
 import { NextPageWithLayout } from "../_app";
-import MainLayout from "../../components/layouts/MainLayout";
+import MainLayout, {
+  MAIN_LAYOUT_TITLE,
+} from "../../components/layouts/MainLayout";
 
 export const Product: NextPageWithLayout<IProduct> = (props: IProduct) => {
   const [isChangingSku, setIsChangingSku] = useState(false);
@@ -51,7 +53,9 @@ Product.getLayout = function getLayout(page: ReactElement, pageProps, ctx?) {
     <>
       <MainLayout nav={ctx?.nav ?? []}>{page}</MainLayout>
       <Head>
-        <title>{pageProps.product.attributes.name}</title>
+        <title>
+          {MAIN_LAYOUT_TITLE} - {pageProps.product.attributes.name}
+        </title>
         <meta
           name="description"
           content={pageProps.product.attributes.description}

--- a/src/pages/products/[productId].tsx
+++ b/src/pages/products/[productId].tsx
@@ -10,7 +10,7 @@ import {
 import { getAllProducts, getProductById } from "../../services/products";
 import SimpleProductDetail from "../../components/product/SimpleProduct";
 import { ProductContext } from "../../lib/product-util";
-import { useState } from "react";
+import React, { ReactElement, useState } from "react";
 import type { IProduct } from "../../lib/types/product-types";
 
 import { withStoreStaticProps } from "../../lib/store-wrapper-ssg";
@@ -19,8 +19,11 @@ import {
   retrieveChildProps,
   retrieveSimpleProps,
 } from "../../lib/retrieve-product-props";
+import Head from "next/head";
+import { NextPageWithLayout } from "../_app";
+import { getMainLayout } from "../../lib/get-main-layout";
 
-export const Product: NextPage<IProduct> = (props: IProduct) => {
+export const Product: NextPageWithLayout<IProduct> = (props: IProduct) => {
   const [isChangingSku, setIsChangingSku] = useState(false);
 
   const { product } = props;
@@ -40,6 +43,22 @@ export const Product: NextPage<IProduct> = (props: IProduct) => {
         {resolveProductDetailComponent(props)}
       </ProductContext.Provider>
     </Container>
+  );
+};
+
+Product.getLayout = function getLayout(page: ReactElement, pageProps, ctx?) {
+  return (
+    <>
+      {getMainLayout(page, pageProps, ctx)}
+      <Head>
+        <title>{pageProps.product.attributes.name}</title>
+        <meta
+          name="description"
+          content={pageProps.product.attributes.description}
+        />
+      </Head>
+      {page}
+    </>
   );
 };
 

--- a/src/pages/products/[productId].tsx
+++ b/src/pages/products/[productId].tsx
@@ -21,7 +21,7 @@ import {
 } from "../../lib/retrieve-product-props";
 import Head from "next/head";
 import { NextPageWithLayout } from "../_app";
-import { getMainLayout } from "../../lib/get-main-layout";
+import MainLayout from "../../components/layouts/MainLayout";
 
 export const Product: NextPageWithLayout<IProduct> = (props: IProduct) => {
   const [isChangingSku, setIsChangingSku] = useState(false);
@@ -49,7 +49,7 @@ export const Product: NextPageWithLayout<IProduct> = (props: IProduct) => {
 Product.getLayout = function getLayout(page: ReactElement, pageProps, ctx?) {
   return (
     <>
-      {getMainLayout(page, pageProps, ctx)}
+      <MainLayout nav={ctx?.nav ?? []}>{page}</MainLayout>
       <Head>
         <title>{pageProps.product.attributes.name}</title>
         <meta
@@ -57,7 +57,6 @@ Product.getLayout = function getLayout(page: ReactElement, pageProps, ctx?) {
           content={pageProps.product.attributes.description}
         />
       </Head>
-      {page}
     </>
   );
 };

--- a/src/pages/products/[productId].tsx
+++ b/src/pages/products/[productId].tsx
@@ -60,6 +60,14 @@ Product.getLayout = function getLayout(page: ReactElement, pageProps, ctx?) {
           name="description"
           content={pageProps.product.attributes.description}
         />
+        <meta
+          property="og:title"
+          content={`${MAIN_LAYOUT_TITLE} - ${pageProps.product.attributes.name}`}
+        />
+        <meta
+          property="og:description"
+          content={pageProps.product.attributes.description}
+        />
       </Head>
     </>
   );

--- a/src/pages/search/[...node].tsx
+++ b/src/pages/search/[...node].tsx
@@ -10,7 +10,9 @@ import { buildBreadcrumbLookup } from "../../lib/build-breadcrumb-lookup";
 import React, { ReactElement } from "react";
 import Head from "next/head";
 import { StoreContext } from "@elasticpath/react-shopper-hooks";
-import MainLayout from "../../components/layouts/MainLayout";
+import MainLayout, {
+  MAIN_LAYOUT_TITLE,
+} from "../../components/layouts/MainLayout";
 
 interface INodeSearch extends ISearch {
   nodeName?: string | string[];
@@ -29,7 +31,12 @@ NodeSearch.getLayout = function getLayout(
     <>
       <MainLayout nav={ctx?.nav ?? []}>{page}</MainLayout>
       <Head>
-        <title>{pageProps.node.join("/")}</title>
+        <meta
+          property="og:title"
+          content={`${MAIN_LAYOUT_TITLE} - ${
+            pageProps.node[pageProps.node.length - 1]
+          }`}
+        />
         <meta name="description" content={pageProps.node.join("/")} />
       </Head>
     </>

--- a/src/pages/search/[...node].tsx
+++ b/src/pages/search/[...node].tsx
@@ -10,7 +10,7 @@ import { buildBreadcrumbLookup } from "../../lib/build-breadcrumb-lookup";
 import React, { ReactElement } from "react";
 import Head from "next/head";
 import { StoreContext } from "@elasticpath/react-shopper-hooks";
-import { getMainLayout } from "../../lib/get-main-layout";
+import MainLayout from "../../components/layouts/MainLayout";
 
 interface INodeSearch extends ISearch {
   nodeName?: string | string[];
@@ -27,12 +27,11 @@ NodeSearch.getLayout = function getLayout(
 ) {
   return (
     <>
-      {getMainLayout(page, pageProps, ctx)}
+      <MainLayout nav={ctx?.nav ?? []}>{page}</MainLayout>
       <Head>
         <title>{pageProps.node.join("/")}</title>
         <meta name="description" content={pageProps.node.join("/")} />
       </Head>
-      {page}
     </>
   );
 };

--- a/src/pages/search/[...node].tsx
+++ b/src/pages/search/[...node].tsx
@@ -31,13 +31,17 @@ NodeSearch.getLayout = function getLayout(
     <>
       <MainLayout nav={ctx?.nav ?? []}>{page}</MainLayout>
       <Head>
+        <title>
+          {MAIN_LAYOUT_TITLE} - {pageProps.node[pageProps.node.length - 1]}
+        </title>
+        <meta name="description" content={pageProps.node.join("/")} />
         <meta
           property="og:title"
           content={`${MAIN_LAYOUT_TITLE} - ${
             pageProps.node[pageProps.node.length - 1]
           }`}
         />
-        <meta name="description" content={pageProps.node.join("/")} />
+        <meta property="og:description" content={pageProps.node.join("/")} />
       </Head>
     </>
   );

--- a/src/pages/search/[...node].tsx
+++ b/src/pages/search/[...node].tsx
@@ -7,6 +7,10 @@ import {
 } from "../../lib/search-props";
 import Search from "../../components/search/SearchPage";
 import { buildBreadcrumbLookup } from "../../lib/build-breadcrumb-lookup";
+import React, { ReactElement } from "react";
+import Head from "next/head";
+import { StoreContext } from "@elasticpath/react-shopper-hooks";
+import { getMainLayout } from "../../lib/get-main-layout";
 
 interface INodeSearch extends ISearch {
   nodeName?: string | string[];
@@ -15,6 +19,23 @@ interface INodeSearch extends ISearch {
 export function NodeSearch(props: INodeSearch): JSX.Element {
   return <Search {...props} />;
 }
+
+NodeSearch.getLayout = function getLayout(
+  page: ReactElement,
+  pageProps: { node: string[] },
+  ctx?: StoreContext
+) {
+  return (
+    <>
+      {getMainLayout(page, pageProps, ctx)}
+      <Head>
+        <title>{pageProps.node.join("/")}</title>
+        <meta name="description" content={pageProps.node.join("/")} />
+      </Head>
+      {page}
+    </>
+  );
+};
 
 export const getServerSideProps = withStoreServerSideProps<
   ISearch,

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -7,6 +7,21 @@ import {
 } from "../../lib/search-props";
 import Search from "../../components/search/SearchPage";
 import { buildBreadcrumbLookup } from "../../lib/build-breadcrumb-lookup";
+import React, { ReactElement } from "react";
+import Head from "next/head";
+import MainLayout from "../../components/layouts/MainLayout";
+
+Search.getLayout = function getLayout(page: ReactElement, pageProps, ctx) {
+  return (
+    <>
+      <MainLayout nav={ctx?.nav ?? []}>{page}</MainLayout>
+      <Head>
+        <title>{pageProps.node.join("/")}</title>
+        <meta name="description" content={pageProps.node.join("/")} />
+      </Head>
+    </>
+  );
+};
 
 export const getServerSideProps = withStoreServerSideProps<
   ISearch,

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -11,13 +11,13 @@ import React, { ReactElement } from "react";
 import Head from "next/head";
 import MainLayout from "../../components/layouts/MainLayout";
 
-Search.getLayout = function getLayout(page: ReactElement, pageProps, ctx) {
+Search.getLayout = function getLayout(page: ReactElement, _, ctx) {
   return (
     <>
       <MainLayout nav={ctx?.nav ?? []}>{page}</MainLayout>
       <Head>
-        <title>{pageProps.node.join("/")}</title>
-        <meta name="description" content={pageProps.node.join("/")} />
+        <title>Search</title>
+        <meta name="description" content="Search for products" />
       </Head>
     </>
   );

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -20,6 +20,8 @@ Search.getLayout = function getLayout(page: ReactElement, _, ctx) {
       <Head>
         <title>{MAIN_LAYOUT_TITLE} - Search</title>
         <meta name="description" content="Search for products" />
+        <meta property="og:title" content={`${MAIN_LAYOUT_TITLE} - Search`} />
+        <meta property="og:description" content="Search for products" />
       </Head>
     </>
   );

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -9,14 +9,16 @@ import Search from "../../components/search/SearchPage";
 import { buildBreadcrumbLookup } from "../../lib/build-breadcrumb-lookup";
 import React, { ReactElement } from "react";
 import Head from "next/head";
-import MainLayout from "../../components/layouts/MainLayout";
+import MainLayout, {
+  MAIN_LAYOUT_TITLE,
+} from "../../components/layouts/MainLayout";
 
 Search.getLayout = function getLayout(page: ReactElement, _, ctx) {
   return (
     <>
       <MainLayout nav={ctx?.nav ?? []}>{page}</MainLayout>
       <Head>
-        <title>Search</title>
+        <title>{MAIN_LAYOUT_TITLE} - Search</title>
         <meta name="description" content="Search for products" />
       </Head>
     </>


### PR DESCRIPTION
SEO optimization:

- Chacra `Text` component replaced with `Heading` where text is header;
- `/search` page is fixed. Now we can see All categories again;
- "Trending Products" link changed from `/category/${nodeId} to `/search`;
- Title, meta, and open graph meta tags added to `/search`, `/search/:slug`, `/products/:id` pages.