### PR TITLE
fix: possible for hit to not have a price

### DIFF
--- a/src/components/search/Hit.tsx
+++ b/src/components/search/Hit.tsx
@@ -23,7 +23,8 @@ import { EP_CURRENCY_CODE } from "../../lib/resolve-ep-currency-code";
 export default function HitComponent({ hit }: { hit: SearchHit }): JSX.Element {
   const { ep_price, ep_name, objectID, ep_main_image_url, ep_description } =
     hit;
-  const currency_price = ep_price[EP_CURRENCY_CODE];
+
+  const currencyPrice = ep_price?.[EP_CURRENCY_CODE];
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
@@ -66,17 +67,15 @@ export default function HitComponent({ hit }: { hit: SearchHit }): JSX.Element {
         >
           {ep_description}
         </Text>
-        {ep_price && (
+        {currencyPrice && (
           <Flex alignItems="center" mt="1">
             <Price
-              price={currency_price.formatted_price}
+              price={currencyPrice.formatted_price}
               currency={EP_CURRENCY_CODE}
             />
-            {currency_price.sale_prices && (
+            {currencyPrice.sale_prices && (
               <StrikePrice
-                price={
-                  currency_price.sale_prices.original_price.formatted_price
-                }
+                price={currencyPrice.sale_prices.original_price.formatted_price}
                 currency={EP_CURRENCY_CODE}
                 fontSize="lg"
               />

--- a/src/components/search/SearchHit.ts
+++ b/src/components/search/SearchHit.ts
@@ -36,7 +36,7 @@ export interface SearchHit extends BaseHit {
   ep_categories: string[];
   ep_description: string;
   ep_name: string;
-  ep_price: HitPrice;
+  ep_price?: HitPrice;
   ep_sku: string;
   ep_slug: string;
   ep_main_image_url: string;

--- a/src/components/search/SearchModal.tsx
+++ b/src/components/search/SearchModal.tsx
@@ -103,6 +103,9 @@ const SearchBox = ({
 const HitComponent = ({ hit }: { hit: SearchHit }) => {
   const { ep_price, ep_main_image_url, ep_name, ep_sku, ep_slug, objectID } =
     hit;
+
+  const currencyPrice = ep_price?.[EP_CURRENCY_CODE];
+
   return (
     <LinkBox>
       <Grid
@@ -142,9 +145,11 @@ const HitComponent = ({ hit }: { hit: SearchHit }) => {
           </Text>
         </GridItem>
         <GridItem colSpan={2}>
-          <Text fontSize="sm" fontWeight="semibold">
-            {ep_price[EP_CURRENCY_CODE].formatted_price}
-          </Text>
+          {currencyPrice && (
+            <Text fontSize="sm" fontWeight="semibold">
+              {currencyPrice.formatted_price}
+            </Text>
+          )}
         </GridItem>
       </Grid>
     </LinkBox>


### PR DESCRIPTION
It's possible that ep_price property on the hits returned from algolia are undefined. This PR handles that correctly.